### PR TITLE
`std_error` estimation heuristic

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -179,15 +179,28 @@ end
 ################################################################################
 
 
+# Heuristic for selecting the level with the (presumably) most reliable
+# standard error estimate:
+# Take the highest lvl with at least 32 bins.
+# (Chose 32 based on https://doi.org/10.1119/1.3247985)
+function _select_lvl_for_std_error(B::BinnerA{N,T})::Int64 where {N, T}
+    n = B.count[1]
+    n == 0 && (return 0)
+    max_bs = n / 32
+
+    i = findlast(bs -> bs <= max_bs, 2 .^ (0:N))
+    isnothing(i) ? 1 : i
+end
+
 """
     std_error(BinningAnalysis[, lvl=0])
 
 Calculates the standard error for a given level.
 """
-function std_error(B::BinnerA{N, T}, lvl::Int64=0) where {N, T <: Number}
+function std_error(B::BinnerA{N, T}, lvl::Int64=_select_lvl_for_std_error(B)) where {N, T <: Number}
     sqrt(varN(B, lvl))
 end
-function std_error(B::BinnerA{N, T}, lvl::Int64=0) where {N, T <: AbstractArray}
+function std_error(B::BinnerA{N, T}, lvl::Int64=_select_lvl_for_std_error(B)) where {N, T <: AbstractArray}
     sqrt.(varN(B, lvl))
 end
 


### PR DESCRIPTION
As discussed in #1, this PR makes `std_error` always default to the standard error of the level which has at least 32 bins.

The number 32 was roughly chosen based on https://doi.org/10.1119/1.3247985 (it suggests 30 but 32 is nicer 😃).

In my eyes, this closes #1.